### PR TITLE
Document exposing VNC port securely via SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,21 @@ Note that the server will bind to all available network interfaces by
 default, so only run this if the tablet's WiFi is disconnected or
 connected to a trusted network. iptables rules could be used to
 restrict traffic.
+
+Alternatively you can make the server listen on localhost only and use SSH port
+forwarding to encrypt the connection between your computer and the Remarkable.  
+This also prevents publicly exposing the unprotected VNC port.
+
+On the Remarkable start the server with `-listen localhost`:
+
+```sh
+/path/to/rM2-vnc-server-standalone -listen localhost
+```
+
+On your computer forward a local port via SSH to the VNC port:
+
+```sh
+ssh -NL localhost:5901:localhost:5900 root@<remarkable-ip>
+```
+
+Configure your VNC client to connect to `localhost:5901`.


### PR DESCRIPTION
Hey @pl-semiotics thanks for this fantastic piece of software. It absolutely crushes https://github.com/rien/reStream in terms of latency and throughput, great work!

I noticed you recommend restricting the VNC port with iptables. I'm not sure if iptables even runs on the Remarkable (not out of the box at least). Fortunately libvncserver allows to bind on localhost only, which combined with an SSH tunnel allows to securely connect to the VNC server without exposing it publicly. I don't observe any increased latency running this way, it's still lightning fast (even via WiFi)!

Perhaps this can be mentioned in the README.